### PR TITLE
모델 다운로드 코드 및  docker run 파일의 오타 수정

### DIFF
--- a/arm_edge/docker_run_gRPC.sh
+++ b/arm_edge/docker_run_gRPC.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+this_pwd=$(pwd)
+
 docker run --rm \
         --gpus all \
         -p 8500:8500 \
-        -v ./models/:/models/ \
+        -v $this_pwd/models/:/models/ \
         edge-tf-serving:latest

--- a/arm_edge/models/model_download.sh
+++ b/arm_edge/models/model_download.sh
@@ -24,6 +24,6 @@ curl -O https://edge-inference.s3.us-west-2.amazonaws.com/NLP/bert_imdb.zip
 unzip -q bert_imdb.zip && rm bert_imdb.zip
 mkdir bert_imdb/1/ && mv bert_imdb/* bert_imdb/1/
 
-crul -O https://edge-inference.s3.us-west-2.amazonaws.com/NLP/distilbert_sst2.zip
+curl -O https://edge-inference.s3.us-west-2.amazonaws.com/NLP/distilbert_sst2.zip
 unzip -q distilbert_sst2.zip && rm distilbert_sst2.zip
 mkdir distilbert_sst2/1/ && mv distilbert_sst2/* distilbert_sst2/1/


### PR DESCRIPTION
- model_download.sh에서 crul오타를 curl로 수정
- doker_run_gRPC.sh 파일의 이름을 docker_run_gRPC.sh로 수정하고 -v 옵션을 절대경로로 수정함